### PR TITLE
Fix typespec for Tds.Result.t()

### DIFF
--- a/lib/tds/result.ex
+++ b/lib/tds/result.ex
@@ -13,7 +13,7 @@ defmodule Tds.Result do
   @typedoc "The result of a database query."
   @type t :: %__MODULE__{
           columns: nil | [String.t()],
-          rows: [tuple],
+          rows: nil | [[any()]],
           num_rows: integer
         }
 


### PR DESCRIPTION
`Tds.query` returns a list of lists as `rows`. Also added the `nil` back because the default constructor for the struct is `nil`.