### PR TITLE
Returned info messages

### DIFF
--- a/lib/tds/messages.ex
+++ b/lib/tds/messages.ex
@@ -166,6 +166,10 @@ defmodule Tds.Messages do
         c = %{c | rows: [row | c.rows], num_rows: c.num_rows + 1}
         {m, c, s}
 
+      {:info, info}, {msg_result() = m, c, s} ->
+        c = Map.update!(c || %Tds.Result{}, :messages, &[info | &1 || []])
+        {m, c, s}
+
       {token, %{status: status, rows: num_rows}}, {msg_result(set: set) = m, c, s}
       when token in [:done, :doneinproc, :doneproc] ->
         cond do

--- a/lib/tds/result.ex
+++ b/lib/tds/result.ex
@@ -14,8 +14,9 @@ defmodule Tds.Result do
   @type t :: %__MODULE__{
           columns: nil | [String.t()],
           rows: nil | [[any()]],
-          num_rows: integer
+          num_rows: integer,
+          messages: nil | [map()]
         }
 
-  defstruct columns: nil, rows: nil, num_rows: 0
+  defstruct columns: nil, rows: nil, num_rows: 0, messages: nil
 end

--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -176,18 +176,6 @@ defmodule Tds.Tokens do
       line_number: line_number
     }
 
-    Logger.debug(fn ->
-      [
-        "(Tds.Info)",
-        "Line",
-        to_string(info.line_number),
-        "(Class #{info.class})",
-        info.msg_text
-      ]
-      |> Enum.intersperse(" ")
-      |> IO.iodata_to_binary()
-    end)
-
     # tokens = Keyword.update(tokens, :info, [i], &[i | &1])
     {{:info, info}, tail, collmetadata}
   end


### PR DESCRIPTION
Hi,

I returned the info messages instead of logging them.

The info message can be generated by SQL Server as part of the query result. Example Warning: Null value is Eliminated by an Aggregate or Other SET Operation. Or it can be generated without a query result by a user defined stored procedure using RAISERROR.

I added the messages key in Tds.Result and info messages are placed into it with the latest info message at the head of the list and the oldest at the tail. This design has been patterned after how Postgrex handles RAISE INFO to provide similar functionality.