### PR TITLE
Fix issue 140

### DIFF
--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -401,7 +401,7 @@ defmodule Tds.Tokens do
             rest::binary
           >> = tail
 
-	  {hostname, instance} =
+          {hostname, instance} =
             UCS2.to_string(alt_host)
             |> String.split("\\")
             |> case do

--- a/lib/tds/tokens.ex
+++ b/lib/tds/tokens.ex
@@ -401,8 +401,17 @@ defmodule Tds.Tokens do
             rest::binary
           >> = tail
 
+	  {hostname, instance} =
+            UCS2.to_string(alt_host)
+            |> String.split("\\")
+            |> case do
+              [host, instance] -> {host, instance}
+              [host] -> {host, nil}
+            end
+
           routing = %{
-            hostname: UCS2.to_string(alt_host),
+            hostname: hostname,
+            instance: instance,
             port: port
           }
 


### PR DESCRIPTION
When the Azure Sql Server response the login message with a 0x14 (redirect to), the server send the host with the instance server together (host\instance). This causes the redirection fail with an error nxdomain because the url is invalid, I added the split the hostname and the instance in the decode_envchange 