### PR TITLE
Updated changelog for v2.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.3.5 (2024-01-23)
+### Improvements
+* Removed unnecessary append of possibly large binaries for floats
+
+
 ## v2.3.4 (2023-09-02)
 ### Improvements
 * Add set_cursor_close_on_commit connection parameter


### PR DESCRIPTION
Added a section for v2.3.5
with a note about no longer appending possibly large binaries for floating point numbers