### PR TITLE
Fix encoding for decimals in scientific notation

### DIFF
--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -1300,12 +1300,12 @@ defmodule Tds.Types do
         -1 -> 0
       end
 
-    d_abs = Decimal.abs(d)
-
-    value = d_abs.coef
-
     value_binary =
       value
+      |> Decimal.abs()
+      |> Decimal.to_string(:normal)
+      |> String.replace(".", "")
+      |> String.to_integer()
       |> :binary.encode_unsigned(:little)
 
     value_size = byte_size(value_binary)
@@ -1318,8 +1318,8 @@ defmodule Tds.Types do
         precision <= 38 -> 16
       end
 
-    {byte_len, padding} = {len, len - value_size}
-    byte_len = byte_len + 1
+    padding = len - value_size
+    byte_len = len + 1
     value_binary = value_binary <> <<0::size(padding)-unit(8)>>
     <<byte_len>> <> <<sign>> <> value_binary
   end

--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -687,12 +687,10 @@ defmodule Tds.Types do
 
   # Decimal
   def decode_decimal(precision, scale, <<sign::int8(), value::binary>>) do
+    set_decimal_precision(precision)
+
     size = byte_size(value)
     <<value::little-size(size)-unit(8)>> = value
-
-    Decimal.Context.get()
-    |> Map.put(:precision, precision)
-    |> Decimal.Context.set()
 
     case sign do
       0 -> Decimal.new(-1, value, -scale)
@@ -878,9 +876,7 @@ defmodule Tds.Types do
   end
 
   def encode_decimal_type(%Parameter{value: value}) do
-    d_ctx = Decimal.Context.get()
-    d_ctx = %{d_ctx | precision: 38}
-    Decimal.Context.set(d_ctx)
+    set_decimal_precision(38)
 
     value_list =
       value
@@ -933,9 +929,7 @@ defmodule Tds.Types do
   end
 
   def encode_float_type(%Parameter{value: %Decimal{} = value}) do
-    d_ctx = Decimal.Context.get()
-    d_ctx = %{d_ctx | precision: 38}
-    Decimal.Context.set(d_ctx)
+    set_decimal_precision(38)
 
     value_list =
       value
@@ -1124,9 +1118,7 @@ defmodule Tds.Types do
   end
 
   def encode_decimal_descriptor(%Parameter{value: %Decimal{} = dec}) do
-    d_ctx = Decimal.Context.get()
-    d_ctx = %{d_ctx | precision: 38}
-    Decimal.Context.set(d_ctx)
+    set_decimal_precision(38)
 
     value_list =
       dec
@@ -1284,9 +1276,7 @@ defmodule Tds.Types do
 
   # decimal
   def encode_data(@tds_data_type_decimaln, %Decimal{} = value, attr) do
-    d_ctx = Decimal.Context.get()
-    d_ctx = %{d_ctx | precision: 38}
-    Decimal.Context.set(d_ctx)
+    set_decimal_precision(38)
     precision = attr[:precision]
 
     d =
@@ -1882,5 +1872,11 @@ defmodule Tds.Types do
     type = @tds_data_type_datetimeoffsetn
     data = <<type, 0x07>>
     {type, data, scale: 7}
+  end
+
+  defp set_decimal_precision(precision) do
+    Decimal.Context.get()
+    |> Map.put(:precision, precision)
+    |> Decimal.Context.set()
   end
 end

--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -695,6 +695,7 @@ defmodule Tds.Types do
     case sign do
       0 -> Decimal.new(-1, value, -scale)
       1 -> Decimal.new(1, value, -scale)
+      _ -> raise ArgumentError, "Sign value out of range. Expected 0 or 1, got #{inspect(sign)}"
     end
   end
 

--- a/lib/tds/types.ex
+++ b/lib/tds/types.ex
@@ -696,7 +696,7 @@ defmodule Tds.Types do
 
     case sign do
       0 -> Decimal.new(-1, value, -scale)
-      _ -> Decimal.new(1, value, -scale)
+      1 -> Decimal.new(1, value, -scale)
     end
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -131,12 +131,13 @@ end
   CREATE TABLE [uniques] ([id] int NOT NULL, CONSTRAINT UIX_uniques_id UNIQUE([id]))
   """)
 
-{"Changed database context to 'test'." <> _, 0} =
+{"", 0} =
   Tds.TestHelper.sqlcmd(opts, """
-  USE test
-  GO
-  CREATE SCHEMA test;
+  IF NOT EXISTS (SELECT * FROM sys.schemas WHERE name = 'test')
+  EXEC('CREATE SCHEMA [test]')
   """)
+
+{"Changed database context to 'test'." <> _, 0} = Tds.TestHelper.sqlcmd(opts, "USE test;")
 
 # :dbg.start()
 # :dbg.tracer()

--- a/test/types/types_test.exs
+++ b/test/types/types_test.exs
@@ -208,7 +208,7 @@ defmodule Tds.TypesTest do
       # %Tds.Error{message: nil, mssql: %{state: 8, number: 8115, line_number:
       # 1, msg_text: \"Arithmetic overflow error converting numeric to data type numeric.\",
       # server_name: \"04e0392f6c76\", class: 16, proc_name: \"\"}}
-      message = ~r/Axrithmetic overflow error converting numeric to data type numeric/
+      message = ~r/Arithmetic overflow error converting numeric to data type numeric/
       assert_raise MatchError, message, fn -> insert_decimal(value, context) end
     end
 

--- a/test/types/types_test.exs
+++ b/test/types/types_test.exs
@@ -1,0 +1,185 @@
+defmodule Tds.TypesTest do
+  use ExUnit.Case, async: false
+
+  alias Tds.Parameter
+
+  import Tds.TestHelper
+
+  require Logger
+
+  @tds_data_type_decimaln 0x6A
+
+  setup do
+    {:ok, pid} = Tds.start_link(opts())
+
+    {:ok, [pid: pid]}
+  end
+
+  defp create_table(context) do
+    precision = context[:precision] || 10
+    scale = context[:scale] || 4
+
+    if not is_integer(precision) do
+      raise ArgumentError, "precision must be an integer"
+    end
+
+    if not is_integer(scale) do
+      raise ArgumentError, "scale must be an integer"
+    end
+
+    query("DROP TABLE IF EXISTS foo", [])
+    query("CREATE TABLE foo (col DECIMAL(#{precision}, #{scale}) NOT NULL)", [])
+  end
+
+  defp insert_decimal(%Decimal{} = value, context) do
+    query("TRUNCATE TABLE foo", [])
+
+    :ok =
+      query("INSERT INTO foo (col) VALUES (@1)", [
+        %Parameter{name: "@1", value: value, type: :decimal}
+      ])
+
+    {:ok, result} = Tds.query(context[:pid], "SELECT col FROM foo", [])
+    %Tds.Result{rows: [[value]]} = result
+    value
+  end
+
+  describe "encode_data/3" do
+    test "encodes decimal type", _context do
+      value = Decimal.new("1000")
+      attr = [precision: 8, scale: 4]
+
+      # assert <<5, 1, 128, 150, 152, 0>> =
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 5
+      assert sign == 1
+      assert <<232, 3, 0, 0>> = value_binary
+      assert :binary.decode_unsigned(value_binary, :little) == 1000
+    end
+
+    test "encodes decimal type with scientific notation", _context do
+      value = Decimal.new("1E+3")
+      attr = [precision: 8, scale: 4]
+
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 5
+      assert sign == 1
+      assert <<232, 3, 0, 0>> = value_binary
+      assert :binary.decode_unsigned(value_binary, :little) == 1000
+    end
+
+    # Decimal.new("-1E+3")
+    test "encodes negative decimal with scientific notation", _context do
+      value = Decimal.new("-1E+3")
+      attr = [precision: 8, scale: 4]
+
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 5
+      assert sign == 0
+      assert <<232, 3, 0, 0>> = value_binary
+      assert :binary.decode_unsigned(value_binary, :little) == 1000
+    end
+
+    test "encodes decimal type with precision", _context do
+      value = Decimal.new("1000.0000")
+      attr = [precision: 8, scale: 4]
+
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 5
+      assert sign == 1
+      assert <<128, 150, 152, 0>> = value_binary
+      assert :binary.decode_unsigned(value_binary, :little) == 10_000_000
+    end
+
+    test "encodes negative decimal", _context do
+      value = Decimal.new("-1000.0000")
+      attr = [precision: 8, scale: 4]
+
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 5
+      assert sign == 0
+      assert <<128, 150, 152, 0>> = value_binary
+      assert :binary.decode_unsigned(value_binary, :little) == 10_000_000
+    end
+
+    test "encodes decimal type for 1000.1234", _context do
+      value = Decimal.new("1000.1234")
+      attr = [precision: 8, scale: 4]
+
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 5
+      assert sign == 1
+      assert <<82, 155, 152, 0>> = value_binary
+      assert :binary.decode_unsigned(value_binary, :little) == 10_001_234
+    end
+
+    test "encodes very large decimal", _context do
+      value = Decimal.new("9999999999.9999")
+      attr = [precision: 14, scale: 4]
+
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 9
+      assert sign == 1
+      assert :binary.decode_unsigned(value_binary, :little) == 99_999_999_999_999
+    end
+
+    test "encodes very small decimal", _context do
+      value = Decimal.new("0.0001")
+      attr = [precision: 5, scale: 4]
+
+      assert <<byte_len>> <> <<sign>> <> value_binary =
+               Tds.Types.encode_data(@tds_data_type_decimaln, value, attr)
+
+      assert byte_len == 5
+      assert sign == 1
+      assert :binary.decode_unsigned(value_binary, :little) == 1
+    end
+  end
+
+  describe "inserting decimal values into the database" do
+    setup :create_table
+
+    test "inserts various decimal values", context do
+      assert insert_decimal(Decimal.new("1000"), context) == Decimal.new("1000.0000")
+      assert insert_decimal(Decimal.new("1000.0000"), context) == Decimal.new("1000.0000")
+      assert insert_decimal(Decimal.new("1000.1234"), context) == Decimal.new("1000.1234")
+      assert insert_decimal(Decimal.new("-1000.0000"), context) == Decimal.new("-1000.0000")
+
+      # Decimals can be scientific notation when converted from float:
+      # iex> Decimal.from_float(1000.0)
+      # Decimal.new("1E+3")
+      assert insert_decimal(Decimal.new("1E+3"), context) == Decimal.new("1000.0000")
+      assert insert_decimal(Decimal.new("-1E+3"), context) == Decimal.new("-1000.0000")
+    end
+
+    test "rounds decimals with more decimal places than column", context do
+      assert insert_decimal(Decimal.new("1000.12345678"), context) == Decimal.new("1000.1235")
+    end
+
+    # Maximum precision and scale for SQL Server
+    # https://learn.microsoft.com/en-us/sql/t-sql/data-types/precision-scale-and-length-transact-sql?view=sql-server-ver16#remarks
+    @tag precision: 38, scale: 18
+    test "inserts very large decimal", context do
+      assert insert_decimal(Decimal.new("99999999999999999999.999999999999999999"), context) ==
+               Decimal.new("99999999999999999999.999999999999999999")
+    end
+
+    test "inserts very small decimal", context do
+      assert insert_decimal(Decimal.new("0.0001"), context) == Decimal.new("0.0001")
+    end
+  end
+end


### PR DESCRIPTION
Currently `Decimal.new("1E+3")` (1000.0) gets encoded as `1` in the database.  This fixes the encoder to convert the decimal to a string using `:normal` (without an exponent) instead of using the `value.coef` which is 1.

```elixir
iex> Decimal.new("1E+3") |> Map.delete(:__struct__)
%{coef: 1, exp: 3, sign: 1}
iex> Decimal.new("1000") |> Map.delete(:__struct__)
%{coef: 1000, exp: 0, sign: 1}
```

This was discovered when using `Decimal.from_float(1000.0)` which results in the exponential representation `Decimal.new("1E+3")`, which is valid in elixir.